### PR TITLE
Remove generic from HtmlElement

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -27,6 +27,9 @@
       <action type="remove" dev="sseifert" issue="1">
         Remove deprecated functionality.
       </action>
+      <action type="update" dev="sseifert" issue="3">
+        DOM: Remove generic from HtmlElement class.
+      </action>
       <action type="update" dev="sseifert">
         Switch to AEM 6.5.17 as minimum version.
       </action>

--- a/src/main/java/io/wcm/handler/commons/dom/AbstractElement.java
+++ b/src/main/java/io/wcm/handler/commons/dom/AbstractElement.java
@@ -33,11 +33,10 @@ import org.osgi.annotation.versioning.ConsumerType;
 /**
  * Generic DOM element.
  * This element implementation is derived from JDOM element implementation.
- * @param <T> Class extending Element
  */
 @SuppressWarnings("unchecked")
 @ConsumerType
-public abstract class AbstractElement<T extends AbstractElement> extends org.jdom2.Element {
+public abstract class AbstractElement extends org.jdom2.Element {
   private static final long serialVersionUID = 1L;
 
   // matches all control chars ([\x00-\x1F\x7F]), that are invalid inside XML
@@ -77,9 +76,9 @@ public abstract class AbstractElement<T extends AbstractElement> extends org.jdo
    * @param value Attribute value as long
    * @return Self reference
    */
-  public final T setAttributeValueAsLong(String name, long value) {
+  public AbstractElement setAttributeValueAsLong(String name, long value) {
     setAttribute(name, Long.toString(value));
-    return (T)this;
+    return this;
   }
 
   /**
@@ -108,9 +107,9 @@ public abstract class AbstractElement<T extends AbstractElement> extends org.jdo
    * @param value Attribute value as integer
    * @return Self reference
    */
-  public final T setAttributeValueAsInteger(String name, int value) {
+  public final AbstractElement setAttributeValueAsInteger(String name, int value) {
     setAttribute(name, Integer.toString(value));
-    return (T)this;
+    return this;
   }
 
   /**
@@ -190,11 +189,11 @@ public abstract class AbstractElement<T extends AbstractElement> extends org.jdo
   /**
    * Appends the child to the end of the element's content list.
    * Returns not the element itself (contrary to addContent), but a reference to the newly added element.
-   * @param <ElementType> Type that extends Element
+   * @param <T> Type that extends Element
    * @param element Element to add. Null values are ignored.
    * @return The added element.
    */
-  public final <ElementType extends AbstractElement> ElementType add(ElementType element) {
+  public final <T extends AbstractElement> T add(T element) {
     this.addContent(element);
     return element;
   }
@@ -281,14 +280,14 @@ public abstract class AbstractElement<T extends AbstractElement> extends org.jdo
   }
 
   @Override
-  public String toString() {
+  public final String toString() {
     return new XMLOutputter().outputString(this);
   }
 
   /**
    * @return Content of element serialized as string
    */
-  public String toStringContentOnly() {
+  public final String toStringContentOnly() {
     return new XMLOutputter().outputElementContentString(this);
   }
 

--- a/src/main/java/io/wcm/handler/commons/dom/AbstractHtmlElementFactory.java
+++ b/src/main/java/io/wcm/handler/commons/dom/AbstractHtmlElementFactory.java
@@ -25,10 +25,9 @@ import org.osgi.annotation.versioning.ConsumerType;
 /**
  * Contains factory methods for creating and adding Html elements and specialized types.
  * This class cannot be instanciated directly, but provides factory methods for HtmlElement-based classes.
- * @param <T> Class derived from HtmlElement
  */
 @ConsumerType
-public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends AbstractElement<T> {
+public abstract class AbstractHtmlElementFactory extends AbstractElement {
   private static final long serialVersionUID = 1L;
 
   /**
@@ -44,7 +43,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param elementName Element name
    * @return Html element.
    */
-  public HtmlElement create(String elementName) {
+  public final HtmlElement create(String elementName) {
     return this.add(new HtmlElement(elementName));
   }
 
@@ -53,7 +52,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param text Comment
    * @return Html comment.
    */
-  public HtmlComment createComment(String text) {
+  public final HtmlComment createComment(String text) {
     HtmlComment comment = new HtmlComment(text);
     this.addContent(comment);
     return comment;
@@ -63,7 +62,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds div element.
    * @return Html element.
    */
-  public Div createDiv() {
+  public final Div createDiv() {
     return this.add(new Div());
   }
 
@@ -71,7 +70,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds span element.
    * @return Html element.
    */
-  public Span createSpan() {
+  public final Span createSpan() {
     return this.add(new Span());
   }
 
@@ -80,7 +79,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param text Text
    * @return Html element.
    */
-  public Span createSpan(String text) {
+  public final Span createSpan(String text) {
     return this.add(new Span(text));
   }
 
@@ -88,7 +87,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds anchor (a) element.
    * @return Html element.
    */
-  public Anchor createAnchor() {
+  public final Anchor createAnchor() {
     return this.add(new Anchor());
   }
 
@@ -97,7 +96,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param href Html "href" attribute.
    * @return Html element.
    */
-  public Anchor createAnchor(String href) {
+  public final Anchor createAnchor(String href) {
     return this.add(new Anchor(href));
   }
 
@@ -107,7 +106,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param target Html "target" attribute.
    * @return Html element.
    */
-  public Anchor createAnchor(String href, String target) {
+  public final Anchor createAnchor(String href, String target) {
     return this.add(new Anchor(href, target));
   }
 
@@ -115,7 +114,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds imgage (img) element.
    * @return Html element.
    */
-  public Image createImage() {
+  public final Image createImage() {
     return this.add(new Image());
   }
 
@@ -124,7 +123,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param src Html "src" attribute.
    * @return Html element.
    */
-  public Image createImage(String src) {
+  public final Image createImage(String src) {
     return this.add(new Image(src));
   }
 
@@ -134,7 +133,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param alt Html "alt" attribute.
    * @return Html element.
    */
-  public Image createImage(String src, String alt) {
+  public final Image createImage(String src, String alt) {
     return this.add(new Image(src, alt));
   }
 
@@ -145,7 +144,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param height Html "height" attribute.
    * @return Html element.
    */
-  public Image createImage(String src, int width, int height) {
+  public final Image createImage(String src, int width, int height) {
     return this.add(new Image(src, width, height));
   }
 
@@ -157,7 +156,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param height Html "height" attribute.
    * @return Html element.
    */
-  public Image createImage(String src, String alt, int width, int height) {
+  public final Image createImage(String src, String alt, int width, int height) {
     return this.add(new Image(src, alt, width, height));
   }
 
@@ -165,7 +164,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds script element.
    * @return Html element.
    */
-  public Script createScript() {
+  public final Script createScript() {
     return this.add(new Script());
   }
 
@@ -174,7 +173,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * @param script Script block
    * @return Html element.
    */
-  public Script createScript(String script) {
+  public final Script createScript(String script) {
     return this.add(new Script(script));
   }
 
@@ -182,7 +181,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds noscript element.
    * @return Html element.
    */
-  public NoScript createNoScript() {
+  public final NoScript createNoScript() {
     return this.add(new NoScript());
   }
 
@@ -190,7 +189,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds figure element.
    * @return Html element.
    */
-  public Figure createFigure() {
+  public final Figure createFigure() {
     return this.add(new Figure());
   }
 
@@ -198,7 +197,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds figure caption element.
    * @return Html element.
    */
-  public FigCaption createFigCaption() {
+  public final FigCaption createFigCaption() {
     return this.add(new FigCaption());
   }
 
@@ -206,7 +205,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds video element.
    * @return Html element.
    */
-  public Video createVideo() {
+  public final Video createVideo() {
     return this.add(new Video());
   }
 
@@ -214,7 +213,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds audio element.
    * @return Html element.
    */
-  public Audio createAudio() {
+  public final Audio createAudio() {
     return this.add(new Audio());
   }
 
@@ -222,7 +221,7 @@ public abstract class AbstractHtmlElementFactory<T extends HtmlElement> extends 
    * Creates and adds source element.
    * @return Html element.
    */
-  public Source createSource() {
+  public final Source createSource() {
     return this.add(new Source());
   }
 

--- a/src/main/java/io/wcm/handler/commons/dom/AbstractNonSelfClosingHtmlElement.java
+++ b/src/main/java/io/wcm/handler/commons/dom/AbstractNonSelfClosingHtmlElement.java
@@ -24,11 +24,10 @@ import org.osgi.annotation.versioning.ConsumerType;
 /**
  * Html element wrapper tags that must not rendered self-closing to avoid problems in certain browsers.
  * Mosf of the elements that extend from this class are block-level elements, but not all of them.
- * @param <T> Class derived from HtmlElement
  */
 @ConsumerType
 @SuppressWarnings("java:S110") // # parent inheritance
-public abstract class AbstractNonSelfClosingHtmlElement<T extends HtmlElement> extends HtmlElement<T> {
+public abstract class AbstractNonSelfClosingHtmlElement extends HtmlElement {
   private static final long serialVersionUID = 1L;
 
   /**

--- a/src/main/java/io/wcm/handler/commons/dom/Anchor.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Anchor.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Anchor extends AbstractNonSelfClosingHtmlElement<Anchor> {
+public final class Anchor extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "a";
@@ -152,6 +152,58 @@ public final class Anchor extends AbstractNonSelfClosingHtmlElement<Anchor> {
   public Anchor setAccessKey(String value) {
     setAttribute(ATTRIBUTE_ACCESSKEY, value);
     return this;
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Anchor setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Anchor)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Anchor setId(String value) {
+    return (Anchor)super.setId(value);
+  }
+
+  @Override
+  public Anchor setCssClass(String value) {
+    return (Anchor)super.setCssClass(value);
+  }
+
+  @Override
+  public Anchor addCssClass(String value) {
+    return (Anchor)super.addCssClass(value);
+  }
+
+  @Override
+  public Anchor setStyleString(String value) {
+    return (Anchor)super.setStyleString(value);
+  }
+
+  @Override
+  public Anchor setStyle(String styleAttribute, String styleValue) {
+    return (Anchor)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Anchor setTitle(String value) {
+    return (Anchor)super.setTitle(value);
+  }
+
+  @Override
+  public Anchor setData(String attributeName, String value) {
+    return (Anchor)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Anchor setAttributeValueAsLong(String name, long value) {
+    return (Anchor)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Anchor setText(String text) {
+    return (Anchor)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Area.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Area.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Area extends HtmlElement<Area> {
+public final class Area extends HtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "area";
@@ -189,6 +189,58 @@ public final class Area extends HtmlElement<Area> {
   public Area setCoords(String value) {
     setAttribute(ATTRIBUTE_COORDS, value);
     return this;
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Area setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Area)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Area setId(String value) {
+    return (Area)super.setId(value);
+  }
+
+  @Override
+  public Area setCssClass(String value) {
+    return (Area)super.setCssClass(value);
+  }
+
+  @Override
+  public Area addCssClass(String value) {
+    return (Area)super.addCssClass(value);
+  }
+
+  @Override
+  public Area setStyleString(String value) {
+    return (Area)super.setStyleString(value);
+  }
+
+  @Override
+  public Area setStyle(String styleAttribute, String styleValue) {
+    return (Area)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Area setTitle(String value) {
+    return (Area)super.setTitle(value);
+  }
+
+  @Override
+  public Area setData(String attributeName, String value) {
+    return (Area)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Area setAttributeValueAsLong(String name, long value) {
+    return (Area)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Area setText(String text) {
+    return (Area)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Audio.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Audio.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Audio extends AbstractNonSelfClosingHtmlElement<Audio> {
+public final class Audio extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "audio";
@@ -132,6 +132,58 @@ public final class Audio extends AbstractNonSelfClosingHtmlElement<Audio> {
   public Audio setSrc(String value) {
     setAttribute(ATTRIBUTE_SRC, value);
     return this;
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Audio setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Audio)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Audio setId(String value) {
+    return (Audio)super.setId(value);
+  }
+
+  @Override
+  public Audio setCssClass(String value) {
+    return (Audio)super.setCssClass(value);
+  }
+
+  @Override
+  public Audio addCssClass(String value) {
+    return (Audio)super.addCssClass(value);
+  }
+
+  @Override
+  public Audio setStyleString(String value) {
+    return (Audio)super.setStyleString(value);
+  }
+
+  @Override
+  public Audio setStyle(String styleAttribute, String styleValue) {
+    return (Audio)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Audio setTitle(String value) {
+    return (Audio)super.setTitle(value);
+  }
+
+  @Override
+  public Audio setData(String attributeName, String value) {
+    return (Audio)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Audio setAttributeValueAsLong(String name, long value) {
+    return (Audio)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Audio setText(String text) {
+    return (Audio)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Div.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Div.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Div extends AbstractNonSelfClosingHtmlElement<Div> {
+public final class Div extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "div";
@@ -36,6 +36,58 @@ public final class Div extends AbstractNonSelfClosingHtmlElement<Div> {
    */
   public Div() {
     super(ELEMENT_NAME);
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Div setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Div)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Div setId(String value) {
+    return (Div)super.setId(value);
+  }
+
+  @Override
+  public Div setCssClass(String value) {
+    return (Div)super.setCssClass(value);
+  }
+
+  @Override
+  public Div addCssClass(String value) {
+    return (Div)super.addCssClass(value);
+  }
+
+  @Override
+  public Div setStyleString(String value) {
+    return (Div)super.setStyleString(value);
+  }
+
+  @Override
+  public Div setStyle(String styleAttribute, String styleValue) {
+    return (Div)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Div setTitle(String value) {
+    return (Div)super.setTitle(value);
+  }
+
+  @Override
+  public Div setData(String attributeName, String value) {
+    return (Div)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Div setAttributeValueAsLong(String name, long value) {
+    return (Div)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Div setText(String text) {
+    return (Div)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/FigCaption.java
+++ b/src/main/java/io/wcm/handler/commons/dom/FigCaption.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class FigCaption extends AbstractNonSelfClosingHtmlElement<FigCaption> {
+public final class FigCaption extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "figcaption";
@@ -36,6 +36,58 @@ public final class FigCaption extends AbstractNonSelfClosingHtmlElement<FigCapti
    */
   public FigCaption() {
     super(ELEMENT_NAME);
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected FigCaption setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (FigCaption)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public FigCaption setId(String value) {
+    return (FigCaption)super.setId(value);
+  }
+
+  @Override
+  public FigCaption setCssClass(String value) {
+    return (FigCaption)super.setCssClass(value);
+  }
+
+  @Override
+  public FigCaption addCssClass(String value) {
+    return (FigCaption)super.addCssClass(value);
+  }
+
+  @Override
+  public FigCaption setStyleString(String value) {
+    return (FigCaption)super.setStyleString(value);
+  }
+
+  @Override
+  public FigCaption setStyle(String styleAttribute, String styleValue) {
+    return (FigCaption)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public FigCaption setTitle(String value) {
+    return (FigCaption)super.setTitle(value);
+  }
+
+  @Override
+  public FigCaption setData(String attributeName, String value) {
+    return (FigCaption)super.setData(attributeName, value);
+  }
+
+  @Override
+  public FigCaption setAttributeValueAsLong(String name, long value) {
+    return (FigCaption)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public FigCaption setText(String text) {
+    return (FigCaption)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Figure.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Figure.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Figure extends AbstractNonSelfClosingHtmlElement<Figure> {
+public final class Figure extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "figure";
@@ -36,6 +36,58 @@ public final class Figure extends AbstractNonSelfClosingHtmlElement<Figure> {
    */
   public Figure() {
     super(ELEMENT_NAME);
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Figure setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Figure)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Figure setId(String value) {
+    return (Figure)super.setId(value);
+  }
+
+  @Override
+  public Figure setCssClass(String value) {
+    return (Figure)super.setCssClass(value);
+  }
+
+  @Override
+  public Figure addCssClass(String value) {
+    return (Figure)super.addCssClass(value);
+  }
+
+  @Override
+  public Figure setStyleString(String value) {
+    return (Figure)super.setStyleString(value);
+  }
+
+  @Override
+  public Figure setStyle(String styleAttribute, String styleValue) {
+    return (Figure)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Figure setTitle(String value) {
+    return (Figure)super.setTitle(value);
+  }
+
+  @Override
+  public Figure setData(String attributeName, String value) {
+    return (Figure)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Figure setAttributeValueAsLong(String name, long value) {
+    return (Figure)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Figure setText(String text) {
+    return (Figure)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/HtmlElement.java
+++ b/src/main/java/io/wcm/handler/commons/dom/HtmlElement.java
@@ -28,11 +28,10 @@ import org.osgi.annotation.versioning.ConsumerType;
 /**
  * Html element wrapper object.
  * This element class is an extension of JDOM Element.
- * @param <T> Class derived from HtmlElement
  */
 @ConsumerType
 @SuppressWarnings("java:S110") // # parent inheritance
-public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFactory<T> {
+public class HtmlElement extends AbstractHtmlElementFactory {
   private static final long serialVersionUID = 1L;
 
   private static final String ATTRIBUTE_ID = "id";
@@ -76,15 +75,14 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
    * @param value Attribute value as boolean
    * @return Self reference
    */
-  @SuppressWarnings("unchecked")
-  protected final T setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+  protected HtmlElement setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
     if (value) {
       setAttribute(attributeName, attributeName.toLowerCase());
     }
     else {
       removeAttribute(attributeName);
     }
-    return (T)this;
+    return this;
   }
 
   /**
@@ -100,10 +98,9 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
    * @param value Value of attribute
    * @return Self reference
    */
-  @SuppressWarnings("unchecked")
-  public final T setId(String value) {
+  public HtmlElement setId(String value) {
     setAttribute(ATTRIBUTE_ID, value);
-    return (T)this;
+    return this;
   }
 
   /**
@@ -120,10 +117,9 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
    * @param value Value of attribute
    * @return Self reference
    */
-  @SuppressWarnings("unchecked")
-  public final T setCssClass(String value) {
+  public HtmlElement setCssClass(String value) {
     setAttribute(ATTRIBUTE_CLASS, value);
-    return (T)this;
+    return this;
   }
 
   /**
@@ -131,13 +127,12 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
    * @param value Value of attribute
    * @return Self reference
    */
-  @SuppressWarnings("unchecked")
-  public final T addCssClass(String value) {
+  public HtmlElement addCssClass(String value) {
     if (StringUtils.isNotEmpty(value)) {
       return setCssClass(StringUtils.isNotEmpty(getCssClass()) ? getCssClass() + " " + value : value);
     }
     else {
-      return (T)this;
+      return this;
     }
   }
 
@@ -185,10 +180,9 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
    * @param value Value of attribute with style key/value pairs
    * @return Self reference
    */
-  @SuppressWarnings("unchecked")
-  public final T setStyleString(String value) {
+  public HtmlElement setStyleString(String value) {
     setAttribute(ATTRIBUTE_STYLE, value);
-    return (T)this;
+    return this;
   }
 
   /**
@@ -197,8 +191,7 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
    * @param styleValue Style attribute value
    * @return Self reference
    */
-  @SuppressWarnings("unchecked")
-  public final T setStyle(String styleAttribute, String styleValue) {
+  public HtmlElement setStyle(String styleAttribute, String styleValue) {
 
     // Add style to style map
     Map<String, String> styleMap = getStyles();
@@ -213,7 +206,7 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
       styleString.append(';');
     }
     setStyleString(styleString.toString());
-    return (T)this;
+    return this;
   }
 
   /**
@@ -229,10 +222,9 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
    * @param value Value of attribute
    * @return Self reference
    */
-  @SuppressWarnings("unchecked")
-  public final T setTitle(String value) {
+  public HtmlElement setTitle(String value) {
     setAttribute(ATTRIBUTE_TITLE, value);
-    return (T)this;
+    return this;
   }
 
   /**
@@ -250,10 +242,9 @@ public class HtmlElement<T extends HtmlElement> extends AbstractHtmlElementFacto
    * @param value Value of attribute
    * @return Self reference
    */
-  @SuppressWarnings("unchecked")
-  public final T setData(String attributeName, String value) {
+  public HtmlElement setData(String attributeName, String value) {
     setAttribute(ATTRIBUTE_DATA_PREFIX + attributeName, value);
-    return (T)this;
+    return this;
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Image.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Image.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Image extends HtmlElement<Image> {
+public final class Image extends HtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "img";
@@ -275,6 +275,58 @@ public final class Image extends HtmlElement<Image> {
   public Image setUseMap(String value) {
     setAttribute(ATTRIBUTE_USEMAP, value);
     return this;
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Image setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Image)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Image setId(String value) {
+    return (Image)super.setId(value);
+  }
+
+  @Override
+  public Image setCssClass(String value) {
+    return (Image)super.setCssClass(value);
+  }
+
+  @Override
+  public Image addCssClass(String value) {
+    return (Image)super.addCssClass(value);
+  }
+
+  @Override
+  public Image setStyleString(String value) {
+    return (Image)super.setStyleString(value);
+  }
+
+  @Override
+  public Image setStyle(String styleAttribute, String styleValue) {
+    return (Image)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Image setTitle(String value) {
+    return (Image)super.setTitle(value);
+  }
+
+  @Override
+  public Image setData(String attributeName, String value) {
+    return (Image)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Image setAttributeValueAsLong(String name, long value) {
+    return (Image)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Image setText(String text) {
+    return (Image)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Map.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Map.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Map extends AbstractNonSelfClosingHtmlElement<Map> {
+public final class Map extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "map";
@@ -55,6 +55,58 @@ public final class Map extends AbstractNonSelfClosingHtmlElement<Map> {
   public Map setMapName(String value) {
     setAttribute(ATTRIBUTE_NAME, value);
     return this;
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Map setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Map)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Map setId(String value) {
+    return (Map)super.setId(value);
+  }
+
+  @Override
+  public Map setCssClass(String value) {
+    return (Map)super.setCssClass(value);
+  }
+
+  @Override
+  public Map addCssClass(String value) {
+    return (Map)super.addCssClass(value);
+  }
+
+  @Override
+  public Map setStyleString(String value) {
+    return (Map)super.setStyleString(value);
+  }
+
+  @Override
+  public Map setStyle(String styleAttribute, String styleValue) {
+    return (Map)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Map setTitle(String value) {
+    return (Map)super.setTitle(value);
+  }
+
+  @Override
+  public Map setData(String attributeName, String value) {
+    return (Map)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Map setAttributeValueAsLong(String name, long value) {
+    return (Map)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Map setText(String text) {
+    return (Map)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/NoScript.java
+++ b/src/main/java/io/wcm/handler/commons/dom/NoScript.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class NoScript extends AbstractNonSelfClosingHtmlElement<NoScript> {
+public final class NoScript extends AbstractNonSelfClosingHtmlElement {
 
   private static final long serialVersionUID = 1L;
 
@@ -37,6 +37,58 @@ public final class NoScript extends AbstractNonSelfClosingHtmlElement<NoScript> 
    */
   public NoScript() {
     super(ELEMENT_NAME);
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected NoScript setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (NoScript)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public NoScript setId(String value) {
+    return (NoScript)super.setId(value);
+  }
+
+  @Override
+  public NoScript setCssClass(String value) {
+    return (NoScript)super.setCssClass(value);
+  }
+
+  @Override
+  public NoScript addCssClass(String value) {
+    return (NoScript)super.addCssClass(value);
+  }
+
+  @Override
+  public NoScript setStyleString(String value) {
+    return (NoScript)super.setStyleString(value);
+  }
+
+  @Override
+  public NoScript setStyle(String styleAttribute, String styleValue) {
+    return (NoScript)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public NoScript setTitle(String value) {
+    return (NoScript)super.setTitle(value);
+  }
+
+  @Override
+  public NoScript setData(String attributeName, String value) {
+    return (NoScript)super.setData(attributeName, value);
+  }
+
+  @Override
+  public NoScript setAttributeValueAsLong(String name, long value) {
+    return (NoScript)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public NoScript setText(String text) {
+    return (NoScript)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Picture.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Picture.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Picture extends AbstractNonSelfClosingHtmlElement<Picture> {
+public final class Picture extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "picture";
@@ -36,6 +36,58 @@ public final class Picture extends AbstractNonSelfClosingHtmlElement<Picture> {
    */
   public Picture() {
     super(ELEMENT_NAME);
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Picture setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Picture)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Picture setId(String value) {
+    return (Picture)super.setId(value);
+  }
+
+  @Override
+  public Picture setCssClass(String value) {
+    return (Picture)super.setCssClass(value);
+  }
+
+  @Override
+  public Picture addCssClass(String value) {
+    return (Picture)super.addCssClass(value);
+  }
+
+  @Override
+  public Picture setStyleString(String value) {
+    return (Picture)super.setStyleString(value);
+  }
+
+  @Override
+  public Picture setStyle(String styleAttribute, String styleValue) {
+    return (Picture)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Picture setTitle(String value) {
+    return (Picture)super.setTitle(value);
+  }
+
+  @Override
+  public Picture setData(String attributeName, String value) {
+    return (Picture)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Picture setAttributeValueAsLong(String name, long value) {
+    return (Picture)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Picture setText(String text) {
+    return (Picture)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Script.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Script.java
@@ -42,7 +42,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Script extends AbstractNonSelfClosingHtmlElement<Script> {
+public final class Script extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "script";
@@ -128,6 +128,53 @@ public final class Script extends AbstractNonSelfClosingHtmlElement<Script> {
       this.addContent("\n");
     }
     return this;
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Script setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Script)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Script setId(String value) {
+    return (Script)super.setId(value);
+  }
+
+  @Override
+  public Script setCssClass(String value) {
+    return (Script)super.setCssClass(value);
+  }
+
+  @Override
+  public Script addCssClass(String value) {
+    return (Script)super.addCssClass(value);
+  }
+
+  @Override
+  public Script setStyleString(String value) {
+    return (Script)super.setStyleString(value);
+  }
+
+  @Override
+  public Script setStyle(String styleAttribute, String styleValue) {
+    return (Script)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Script setTitle(String value) {
+    return (Script)super.setTitle(value);
+  }
+
+  @Override
+  public Script setData(String attributeName, String value) {
+    return (Script)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Script setAttributeValueAsLong(String name, long value) {
+    return (Script)super.setAttributeValueAsLong(name, value);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Source.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Source.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public class Source extends HtmlElement<Source> {
+public class Source extends HtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "source";
@@ -132,6 +132,58 @@ public class Source extends HtmlElement<Source> {
   public Source setType(String value) {
     setAttribute(ATTRIBUTE_TYPE, value);
     return this;
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Source setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Source)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Source setId(String value) {
+    return (Source)super.setId(value);
+  }
+
+  @Override
+  public Source setCssClass(String value) {
+    return (Source)super.setCssClass(value);
+  }
+
+  @Override
+  public Source addCssClass(String value) {
+    return (Source)super.addCssClass(value);
+  }
+
+  @Override
+  public Source setStyleString(String value) {
+    return (Source)super.setStyleString(value);
+  }
+
+  @Override
+  public Source setStyle(String styleAttribute, String styleValue) {
+    return (Source)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Source setTitle(String value) {
+    return (Source)super.setTitle(value);
+  }
+
+  @Override
+  public Source setData(String attributeName, String value) {
+    return (Source)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Source setAttributeValueAsLong(String name, long value) {
+    return (Source)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Source setText(String text) {
+    return (Source)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Span.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Span.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Span extends AbstractNonSelfClosingHtmlElement<Span> {
+public final class Span extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "span";
@@ -45,6 +45,58 @@ public final class Span extends AbstractNonSelfClosingHtmlElement<Span> {
   public Span(String text) {
     super(ELEMENT_NAME);
     setText(text);
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Span setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Span)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Span setId(String value) {
+    return (Span)super.setId(value);
+  }
+
+  @Override
+  public Span setCssClass(String value) {
+    return (Span)super.setCssClass(value);
+  }
+
+  @Override
+  public Span addCssClass(String value) {
+    return (Span)super.addCssClass(value);
+  }
+
+  @Override
+  public Span setStyleString(String value) {
+    return (Span)super.setStyleString(value);
+  }
+
+  @Override
+  public Span setStyle(String styleAttribute, String styleValue) {
+    return (Span)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Span setTitle(String value) {
+    return (Span)super.setTitle(value);
+  }
+
+  @Override
+  public Span setData(String attributeName, String value) {
+    return (Span)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Span setAttributeValueAsLong(String name, long value) {
+    return (Span)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Span setText(String text) {
+    return (Span)super.setText(text);
   }
 
 }

--- a/src/main/java/io/wcm/handler/commons/dom/Video.java
+++ b/src/main/java/io/wcm/handler/commons/dom/Video.java
@@ -26,7 +26,7 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 @SuppressWarnings("java:S110") // # parent inheritance
-public final class Video extends AbstractNonSelfClosingHtmlElement<Video> {
+public final class Video extends AbstractNonSelfClosingHtmlElement {
   private static final long serialVersionUID = 1L;
 
   private static final String ELEMENT_NAME = "video";
@@ -208,6 +208,58 @@ public final class Video extends AbstractNonSelfClosingHtmlElement<Video> {
   public Video setWidth(long value) {
     setAttributeValueAsLong(ATTRIBUTE_WIDTH, value);
     return this;
+  }
+
+  // -- overwrite methods for builder pattern with covariant return types --
+
+  @Override
+  protected Video setEmptyAttributeValueAsBoolean(String attributeName, boolean value) {
+    return (Video)super.setEmptyAttributeValueAsBoolean(attributeName, value);
+  }
+
+  @Override
+  public Video setId(String value) {
+    return (Video)super.setId(value);
+  }
+
+  @Override
+  public Video setCssClass(String value) {
+    return (Video)super.setCssClass(value);
+  }
+
+  @Override
+  public Video addCssClass(String value) {
+    return (Video)super.addCssClass(value);
+  }
+
+  @Override
+  public Video setStyleString(String value) {
+    return (Video)super.setStyleString(value);
+  }
+
+  @Override
+  public Video setStyle(String styleAttribute, String styleValue) {
+    return (Video)super.setStyle(styleAttribute, styleValue);
+  }
+
+  @Override
+  public Video setTitle(String value) {
+    return (Video)super.setTitle(value);
+  }
+
+  @Override
+  public Video setData(String attributeName, String value) {
+    return (Video)super.setData(attributeName, value);
+  }
+
+  @Override
+  public Video setAttributeValueAsLong(String name, long value) {
+    return (Video)super.setAttributeValueAsLong(name, value);
+  }
+
+  @Override
+  public Video setText(String text) {
+    return (Video)super.setText(text);
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/AnchorTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/AnchorTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,11 @@ class AnchorTest {
 
     anchor.setAccessKey("key1");
     assertEquals("key1", anchor.getAccessKey());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Anchor());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/AreaTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/AreaTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -53,6 +54,11 @@ class AreaTest {
 
     area.setCoords("coords1");
     assertEquals("coords1", area.getCoords());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Area());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/AudioTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/AudioTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -44,6 +45,11 @@ class AudioTest {
 
     audio.setSrc("ref1");
     assertEquals("ref1", audio.getSrc());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Audio());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/DivTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/DivTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,11 @@ class DivTest {
   void testSimpleAttributes() throws Exception {
     Div div = new Div();
     assertEquals("div", div.getName());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Div());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/FigCaptionTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/FigCaptionTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,11 @@ class FigCaptionTest {
   void testSimpleAttributes() throws Exception {
     FigCaption figCaption = new FigCaption();
     assertEquals("figcaption", figCaption.getName());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new FigCaption());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/FigureTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/FigureTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,11 @@ class FigureTest {
   void testSimpleAttributes() throws Exception {
     Figure figure = new Figure();
     assertEquals("figure", figure.getName());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Figure());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/HtmlElementTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/HtmlElementTest.java
@@ -36,7 +36,7 @@ class HtmlElementTest {
 
   private static final Namespace NS_TEST = Namespace.getNamespace("test", "http://test");
 
-  private HtmlElement<?> underTest;
+  private HtmlElement underTest;
 
   @BeforeEach
   void setUp() {

--- a/src/test/java/io/wcm/handler/commons/dom/ImageTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/ImageTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,11 @@ class ImageTest {
     assertEquals("sizes1", img.getSizes());
     assertEquals("#map123", img.getUseMap());
 
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Image());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/MapTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/MapTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,11 @@ class MapTest {
 
     map.setMapName("name1");
     assertEquals("name1", map.getMapName());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Map());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/NoScriptTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/NoScriptTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,11 @@ class NoScriptTest {
   void testSimpleAttributes() throws Exception {
     NoScript noScript = new NoScript();
     assertEquals("noscript", noScript.getName());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new NoScript());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/PictureTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/PictureTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -29,6 +30,11 @@ class PictureTest {
   void testSimpleAttributes() throws Exception {
     Picture picture = new Picture();
     assertEquals("picture", picture.getName());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Picture());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/ScriptTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/ScriptTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethodsSkipText;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,6 +41,11 @@ class ScriptTest {
     Script script2 = new Script("text1");
     assertTrue(script2.getText().contains("text1"));
 
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethodsSkipText(new Script());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/SourceTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/SourceTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,11 @@ class SourceTest {
     assertEquals("type1", source.getType());
     assertEquals("srcset1", source.getSrcSet());
     assertEquals("sizes1", source.getSizes());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Source());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/SpanTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/SpanTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -32,6 +33,11 @@ class SpanTest {
 
     Span span2 = new Span("text1");
     assertEquals("text1", span2.getText());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Span());
   }
 
 }

--- a/src/test/java/io/wcm/handler/commons/dom/TestUtil.java
+++ b/src/test/java/io/wcm/handler/commons/dom/TestUtil.java
@@ -1,0 +1,66 @@
+/*
+ * #%L
+ * wcm.io
+ * %%
+ * Copyright (C) 2024 wcm.io
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package io.wcm.handler.commons.dom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jetbrains.annotations.NotNull;
+
+final class TestUtil {
+
+  private static final String TEST_STRING = "test";
+
+  private TestUtil() {
+    // static methods only
+  }
+
+  static <T extends HtmlElement> void assertDefaultMethodsSkipText(@NotNull T element) {
+    element.setEmptyAttributeValueAsBoolean(TEST_STRING, true);
+    assertEquals(TEST_STRING, element.getAttributeValue(TEST_STRING));
+
+    element.setAttributeValueAsLong(TEST_STRING, 8L);
+    assertEquals("8", element.getAttributeValue(TEST_STRING));
+
+    element.setId(TEST_STRING);
+    assertEquals(TEST_STRING, element.getId());
+
+    element.setCssClass("class1");
+    element.addCssClass("class2");
+    assertEquals("class1 class2", element.getCssClass());
+
+    element.setStyleString("style1:true;");
+    element.setStyle("style2", "false");
+    assertEquals("style1:true;style2:false;", element.getStyleString());
+
+    element.setTitle(TEST_STRING);
+    assertEquals(TEST_STRING, element.getTitle());
+
+    element.setData(TEST_STRING, "1");
+    assertEquals("1", element.getData(TEST_STRING));
+  }
+
+  static <T extends HtmlElement> void assertDefaultMethods(@NotNull T element) {
+    assertDefaultMethodsSkipText(element);
+
+    element.setText(TEST_STRING);
+    assertEquals(TEST_STRING, element.getText());
+  }
+
+}

--- a/src/test/java/io/wcm/handler/commons/dom/VideoTest.java
+++ b/src/test/java/io/wcm/handler/commons/dom/VideoTest.java
@@ -19,6 +19,7 @@
  */
 package io.wcm.handler.commons.dom;
 
+import static io.wcm.handler.commons.dom.TestUtil.assertDefaultMethods;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,11 @@ class VideoTest {
 
     video.setWidth(30);
     assertEquals(30, video.getWidth());
+  }
+
+  @Test
+  void testDefaultMethods() {
+    assertDefaultMethods(new Video());
   }
 
 }


### PR DESCRIPTION
this was used to simplify the implementation of builder pattern for each DOM element class. but it mis-uses the language construct, we implement it in a different way even if this means we need to overwrite a couple of methods in each DOM element class.